### PR TITLE
Update CSS for Rails compatibility

### DIFF
--- a/css/docson.css
+++ b/css/docson.css
@@ -351,7 +351,7 @@
     padding: 0px;
     font-size: 80%;
     font-weight: normal;
-    background: rgba(231, 231, 231, 50);
+    background: rgba(231, 231, 231, 0.5);
 }
 
 .docson .desc table,th,td


### PR DESCRIPTION
Asset pipeline was throwing a '50 is not a valid alpha value in rgba' error.
