### PR TITLE
Only delete the target.__ref if target is defined

### DIFF
--- a/docson.js
+++ b/docson.js
@@ -283,7 +283,9 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
             } else {
                 result = new Handlebars.SafeString("<span class='signature-type-ref'>"+schema.$ref+"</span>");
             }
-            delete target.__ref;
+            if(target) {
+                delete target.__ref;
+            }
             return result;
         }
     });


### PR DESCRIPTION
I had a $ref that couldn't be resolved (because I had mislabeled it - see the commit that fixes it [here](https://github.com/open-contracting/standard/commit/15d11361b58d714b9fd57e63f6f17808a88ff2ee).

But the result was without this if statement nothing renders at all. With this, you just see the $ref literal instead of the embedded definition, which seems correct.

Thanks for your consideration.
