### PR TITLE
Infinite recursion in case of nested circular references

### DIFF
--- a/docson.js
+++ b/docson.js
@@ -264,7 +264,10 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
 
     function renderSchema(schema) {
         if(stack.indexOf(schema) == -1) { // avoid recursion
-            return new Handlebars.SafeString(boxTemplate(schema));
+            stack.push(schema);
+            var ret = new Handlebars.SafeString(boxTemplate(schema));
+            stack.pop();
+            return ret;
         } else {
             return new Handlebars.SafeString(boxTemplate({"description": "_circular reference_"}));
         }

--- a/tests/ref.json
+++ b/tests/ref.json
@@ -140,5 +140,21 @@
                 "valid": false
             }
         ]
-    }    
+    },
+    {
+        "description": "circular refs",
+        "schema": {
+            "definitions": {
+                "a": {
+                    "properties": {
+                        "more": {"$ref": "#/definitions/a"}
+                    }
+                }
+            },
+            "properties": {
+                "prop": {"$ref": "#/definitions/a"}
+            }
+        },
+        "tests": []
+    }
 ]


### PR DESCRIPTION
A schema where a definition is (directly or indirectly) referenced inside itself, like this

````json
{
    "definitions": {
        "a": {
            "properties": {
                "more": {"$ref": "#/definitions/a"}
            }
        }
    },
    "properties": {
        "prop": {"$ref": "#/definitions/a"}
    }
}
````

sends Docson into an infinite recursion.

Expected result:
![image](https://cloud.githubusercontent.com/assets/234094/6600879/72f3aa4c-c812-11e4-8ac3-4be5d4948d9e.png)

The attached commits appear to fix that. I didn’t study the code very closely, so I’m not sure if it is the correct fix, but all tests still pass.