### PR TITLE
Stop circular reference downloading

### DIFF
--- a/docson.js
+++ b/docson.js
@@ -433,7 +433,7 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                 });
             };
 
-            var resolveRefsReentrant = function(schema){
+            var resolveRefsReentrant = function(schema, refStack){
                 traverse(schema).forEach(function(item) {
                     // Fix Swagger weird generation for array.
                     if(item && item.$ref == "array") {
@@ -441,8 +441,10 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                         item.type ="array";
                     }
 
-                    // Fetch external schema
-                    if(this.key === "$ref") {
+                    // Fetch external schema, if it is not a recursive fetch
+                    if(this.key === "$ref" && stack.indexOf(item) == -1 && refStack.indexOf(item) == -1) {
+                        var localStack = refStack.slice();
+                        localStack.push(item);
                         var external = false;
                         //Local meaning local to this server, but not in this file.
                         var local = false;
@@ -473,7 +475,7 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                                 if(content) {
                                     refs[item] = content;
                                     renderBox();
-                                    resolveRefsReentrant(content); 
+                                    resolveRefsReentrant(content, localStack);
                                 }
                             });
                         }
@@ -492,7 +494,7 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                                 if(content) {
                                     refs[item] = content;
                                     renderBox();
-                                    resolveRefsReentrant(content);
+                                    resolveRefsReentrant(content, localStack);
                                 }
                             });
                         }
@@ -500,7 +502,7 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                 });
             };
             
-            resolveRefsReentrant(schema);
+            resolveRefsReentrant(schema, []);
             renderBox();
             
             d.resolve();


### PR DESCRIPTION
The current circular reference detection only works if the reference is a local reference within the same file. If a file needs to be fetched, `resolveRefsReentrant` will run in an infinite loop.

Given a schema like this:

```
{
  "$schema": "http://json-schema.org/draft-04/schema#",

  "title": "Circle",
  "type": "object",

  "properties": {
    "circle": {
      "$ref": "circle.schema.json"
    }
  }
}
```

Docson will download the file over and over again in the background.

This PR fixes that. I did not use the global `stack` as multiple resolveRefsReentrant` can download in parallel. Instead I created a local stack.

Some caveats: If the first file is already `circle.schema.json`, this will not be taken into account as the name of the file is never passed to `docson.doc()`.
The element is actually still rendered several times before `renderSchema` detects the recursion as it's triggered from several places, as far as I can see. Anyway, it might not be too bad if the user still can see the first 3 levels of recursion :wink:
