### PR TITLE
Fix $$expand not adjusting height inside script-enabled iframe

### DIFF
--- a/docson.js
+++ b/docson.js
@@ -366,6 +366,11 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                 element.get(0).resized = resized;
                 resized();
 
+                // For usage of $$expand via embed, where height can get stuck initially
+                for(var waitMs in [100, 500, 1000, 2000, 5000]) {
+                    setTimeout(resized, waitMs);
+                }
+
                 if(highlight) {
                     element.find(".json-schema").each(function(k, schemaElement) {
                         highlight.highlightSchema(schemaElement);


### PR DESCRIPTION
This is a hack to fix the scenario where I do this:

```
<script src="javascripts/docson/widget.js" data-schema="my_schema.json$$expand">
</script>
```

And what happens is the iframe is of insufficient height to show the entire expanded body of docs.  I am not sure of the origin of this problem, but have spent enough time in "make the iframe auto resize to its content height" hell in the past to not want to investigate why :)