### PR TITLE
Use jsonpointer when fetching refs

### DIFF
--- a/docson.js
+++ b/docson.js
@@ -471,7 +471,7 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                                     }
                                 }
                                 if(content) {
-                                    refs[item] = content;
+                                    refs[item] = jsonpointer.get(content, segments[1]);
                                     renderBox();
                                     resolveRefsReentrant(content); 
                                 }
@@ -490,7 +490,7 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                                     }
                                 }
                                 if(content) {
-                                    refs[item] = content;
+                                    refs[item] = jsonpointer.get(content, segments[1]);
                                     renderBox();
                                     resolveRefsReentrant(content);
                                 }


### PR DESCRIPTION
When fetching refs with paths such as other.json#/some/path, use jsonpointer to resolve #/some/path and store just that part of the object in the refs map.
