### PR TITLE
Fix external link

### DIFF
--- a/css/docson.css
+++ b/css/docson.css
@@ -23,6 +23,7 @@
 .docson .box {
     position: relative;
     float: left;
+    width:100%;
     background-color:rgba(255, 255, 255, 0.2);
     border: 1px solid lightgrey;
     border-radius: 4px;
@@ -79,6 +80,7 @@
     color: darkblue;
     padding: 5px 40px 2px 3px;
     float: left;
+    width:100%;
 }
 
 .docson .title {
@@ -93,7 +95,7 @@
 .docson .box-description {
     color: dimgray;
     float: left;
-    max-width: 600px;
+    width:100%;
 }
 
 .docson .end {
@@ -171,6 +173,7 @@
 
 .docson .property-name {
     float: left;
+    width:100%;
     font-family: "Lucida Console", Monaco, monospace;
     min-width: 130px;
 }
@@ -204,8 +207,8 @@
 .docson .signature-type {
     padding-left: 6px;
     float: left;
+    width:100%;
     min-width: 160px;
-    max-width: 320px;
 }
 
 .docson .signature-type-any {
@@ -283,7 +286,7 @@
     padding-bottom: 3px;
     color: dimgray;
     float: left;
-    max-width: 600px;
+    width:100%;
 }
 
 .docson .signature-box-container {
@@ -292,6 +295,7 @@
 
 .docson .box-container {
     float: left;
+    width:100%;
     padding-top: 4px;
     padding-left: 8px;
     display: none;

--- a/docson.js
+++ b/docson.js
@@ -481,7 +481,8 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                             //Local to this server, fetch relative
                             var segments = item.split("#");
                             refs[item] = null;
-                            var p = $.get(baseUrl + segments[0]).then(function(content) {
+                            var isRelativeLink = /^[^\/]/.test(segments[0]);
+                            var p = $.get((isRelativeLink ? baseUrl:"") + segments[0]).then(function(content) {
                                 if(typeof content != "object") {
                                     try {
                                         content = JSON.parse(content);


### PR DESCRIPTION
If you use an absolute path as a $ref it does not get picked up by the app and you end up getting a 404.

Example $ref:"/data/schema.json" works now