### PR TITLE
Embedded with empty "type"

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
                         function receiveMessage(event) {
                             console.log(">", event)
                             if(event.data.id && event.data.id == "docson") {
-                                if(event.data.type) {
+                                if(event.data.hasOwnProperty('type')) {
                                     try {
                                         docson.doc("doc", event.data.definitions, event.data.type).done(function() {
                                             maybeExpand(segments);


### PR DESCRIPTION
This PR fixes a issue where something like `frame.contentWindow.postMessage({ id: "docson", action: "load", definitions: definition, type: ""}, "*");` was not working.