### PR TITLE
Fix build when pnpx is not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "npm run build",
     "build": "npm run clean && npm run build-lib && npm run build-widget",
     "build-widget": "webpack",
-    "build-lib": "pnpx babel src -d lib",
+    "build-lib": "babel src -d lib",
     "clean": "rm -fr lib"
   },
   "repository": {


### PR DESCRIPTION
Running `npm install` (or `npm build`) fails when pnpm/pnpx is not installed.

Babel is already installed in node_modules, so it doesn’t need to be invoked through [p]npx, or am I missing anything? Removing “pnpx” from that command line seems to work for me in any case.