### PR TITLE
Make tests faster by avoiding unnecessary waiting

### DIFF
--- a/integration/basic.test.js
+++ b/integration/basic.test.js
@@ -40,7 +40,7 @@ test('resolve #definitions in non-root schema', async () => {
 
     await page.goto( rootUrl + "#/integration/schemas/def-non-root/User.json");
 
-    await page.waitFor(5000);
+    await page.waitFor('#doc .box .box .box .signature:nth-child(6) .property-name');
     
     await expect( 
         page.evaluate( () => Array.from(document.querySelectorAll('.property-name').values()).map( s => s.innerText ) )
@@ -55,7 +55,7 @@ test('local schema, absolute path', async () =>  {
 
     await page.goto( rootUrl + "#/integration/schemas/local-absolute/main.json");
 
-    await page.waitFor(5000);
+    await page.waitFor('#doc .box .box .desc');
     
     await expect( 
         page.evaluate( () => Array.from(document.querySelectorAll('.desc').values()).map( s => s.innerText ) )
@@ -70,7 +70,7 @@ test('recursive schemas', async () => {
 
     await page.goto( rootUrl + "#/integration/schemas/recursive/circle.json");
 
-    await page.waitFor(5000);
+    await page.waitFor('#doc .box .box .box .desc');
 
     await expect( 
         page.evaluate( () => Array.from(document.querySelectorAll('.desc').values()).map( s => s.innerText ) )
@@ -84,7 +84,7 @@ test('recursive schemas, part II', async () => {
     const page = await ( await browser ).newPage();
 
     await page.goto( rootUrl + "#/integration/schemas/recursive/within_schema.json");
-    await page.waitFor(5000);
+    await page.waitFor('#doc .box .desc p');
 
     let results = await
         page.evaluate( () => Array.from(document.querySelectorAll('p').values()).map( s => s.innerText ) );

--- a/integration/widget.test.js
+++ b/integration/widget.test.js
@@ -31,7 +31,7 @@ test( 'basic', async () => {
 
     let frames = await page.frames();
 
-    await page.waitFor(2000);
+    await frames[1].waitFor('.title');
 
     let title = await frames[1].evaluate( 
         () => document.querySelector('.title').innerText 

--- a/integration/widget.test.js
+++ b/integration/widget.test.js
@@ -3,14 +3,14 @@ const express    = require('express');
 
 const puppeteer = require('puppeteer')
 
-const rootUrl = "http://localhost:3000/";
+const rootUrl = "http://localhost:3001/";
 
 jest.setTimeout(500000);
 
 const server = new Promise( resolve => {
     let app = require( '../src/server' )({ directory: path.join( __dirname, '..' ) });
     let server;
-    server = app.listen( 3000, () => resolve(server) );
+    server = app.listen( 3001, () => resolve(server) );
 }).catch( e => console.log(e) );
 
 const browser = puppeteer.launch({ headless: false });


### PR DESCRIPTION
As I suspected yesterday, it seems like the tests can actually be sped up massively by avoiding hardcoded wait times: Puppeteer allows us to wait for the specific element we want to check instead of waiting for a fixed time and hoping it will be there by then. I’m not sure if there was a reason for doing it this way, but replacing the waits seems to work well for me.

This reduces the total testing time from 26s to 7s for me.

The commit is stacked on #78 because only that allowed me to get meaningful figures, but is independent and could be rebased if desired for a neater branching layout.