### PR TITLE
Fix schema with “properties” and “additionalProperties”

### DIFF
--- a/integration/schemas/additionalProperties.json
+++ b/integration/schemas/additionalProperties.json
@@ -1,0 +1,4 @@
+{
+    "properties": {"foo": {}, "bar": {}},
+    "additionalProperties": {"type": "boolean"}
+}

--- a/public/templates/box.html
+++ b/public/templates/box.html
@@ -142,7 +142,7 @@
             <div class="signature-header">
                 <div class="property-name type-pattern">additional</div>
                 <div class="signature-type">
-                    {{schema ../additionalProperties}}
+                    {{schema additionalProperties}}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Rendering a schema containing both “properties” and “additionalProperties” currently fails with `oops – TypeError: Attempted to assign to readonly property.` printed to the console.

The source of the TypeError is that the “name” helper is invoked with Handlebars’ `nullContext` as the first argument, a read-only empty object, coming from `{{schema ../additionalProperties}}` in _box.html_. This strikes me as making no sense – why get the property from the parent context after checking for it on the current context using `{{#if additionalProperties}}`?

This used to work, but I’m not even sure why – apparently the parent context was the same as the current context at that invocation, at some point. I could’t quite figure out what broke it – bisection indicates it seems to have happened in 7d17a0d, where not much happened in the Docson code, but many dependencies, including Handlebars, were updated over several major versions in the switch from bundled libraries to ones installed by npm. I didn’t dig any deeper than that. 

The attached commits add a test that currently fails, using a schema from _tests/additionalProperties.json_ (if those manual tests were still working, maybe the bug would have been noticed earlier), as well as a fix.

(We are getting closer to the bug I actually wanted to fix, but this is not it yet. 🙂)