### PR TITLE
Fix failure to render a schema containing unresolvable refs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -543,11 +543,15 @@ const highlight = false;
                     // use the normalized uri
                     parentObject.update( uri.toString() );
 
-                    debug(get_ref(uri));
-                    get_ref( uri ).finally( () => {
+                    var refp = get_ref(uri);
+                    debug(refp);
+                    refp.finally( () => {
                         throttled_render();
                         resolve();
-                    });
+                    })
+                    // avoid "unhandled rejection" error - the output may be redundant as the
+                    // browser probably already logged the failure, but better be explicit
+                    .catch(e => { console.warn("Unable to resolve $ref " + uri.toString() + ":", e); });
                 });
             }
 

--- a/src/index.js
+++ b/src/index.js
@@ -404,13 +404,13 @@ const highlight = false;
 
             var refs = {};
             var get_ref = function(uri) {
-                return new Promise( resolve => {
+                return new Promise( (resolve, reject) => {
                     get_document( uri.clone().hash('').toString() ).then(function(schema){
                     refs[uri.toString()] = uri.hash() ? jsonpointer.get( schema, uri.hash() ) : schema;
                 }).then(function(){ 
                     debug('get_ref');
                     resolve();
-                });
+                }, reject);
                 });
             };
 


### PR DESCRIPTION
When the HTTP request to retrieve a referenced external schema failed, the promise rejection was not properly routed to the promise the rendering code was waiting on, so it continued waiting indefinitely and rendered nothing.

When combined with #81 and #80, this causes the “invoice” and “example2” examples in _test.html_ to appear, which were previously missing.