### PR TITLE
Fix issues found in test.html

### DIFF
--- a/integration/basic.test.js
+++ b/integration/basic.test.js
@@ -70,7 +70,7 @@ test('recursive schemas', async () => {
 
     await page.goto( rootUrl + "#/integration/schemas/recursive/circle.json");
 
-    await page.waitFor('#doc .box .box .box .desc');
+    await page.waitFor('#doc .box .box .desc');
 
     await expect( 
         page.evaluate( () => Array.from(document.querySelectorAll('.desc').values()).map( s => s.innerText ) )

--- a/integration/basic.test.js
+++ b/integration/basic.test.js
@@ -40,7 +40,7 @@ test('resolve #definitions in non-root schema', async () => {
 
     await page.goto( rootUrl + "#/integration/schemas/def-non-root/User.json");
 
-    await page.waitFor(5000);
+    await page.waitFor('#doc .box .box .box .signature:nth-child(6) .property-name');
     
     await expect( 
         page.evaluate( () => Array.from(document.querySelectorAll('.property-name').values()).map( s => s.innerText ) )
@@ -55,7 +55,7 @@ test('local schema, absolute path', async () =>  {
 
     await page.goto( rootUrl + "#/integration/schemas/local-absolute/main.json");
 
-    await page.waitFor(5000);
+    await page.waitFor('#doc .box .box .desc');
     
     await expect( 
         page.evaluate( () => Array.from(document.querySelectorAll('.desc').values()).map( s => s.innerText ) )
@@ -70,7 +70,7 @@ test('recursive schemas', async () => {
 
     await page.goto( rootUrl + "#/integration/schemas/recursive/circle.json");
 
-    await page.waitFor(5000);
+    await page.waitFor('#doc .box .box .box .desc');
 
     await expect( 
         page.evaluate( () => Array.from(document.querySelectorAll('.desc').values()).map( s => s.innerText ) )
@@ -84,7 +84,7 @@ test('recursive schemas, part II', async () => {
     const page = await ( await browser ).newPage();
 
     await page.goto( rootUrl + "#/integration/schemas/recursive/within_schema.json");
-    await page.waitFor(5000);
+    await page.waitFor('#doc .box .desc p');
 
     let results = await
         page.evaluate( () => Array.from(document.querySelectorAll('p').values()).map( s => s.innerText ) );

--- a/integration/widget.test.js
+++ b/integration/widget.test.js
@@ -31,7 +31,7 @@ test( 'basic', async () => {
 
     let frames = await page.frames();
 
-    await page.waitFor(2000);
+    await frames[1].waitFor('.title');
 
     let title = await frames[1].evaluate( 
         () => document.querySelector('.title').innerText 

--- a/integration/widget.test.js
+++ b/integration/widget.test.js
@@ -3,14 +3,14 @@ const express    = require('express');
 
 const puppeteer = require('puppeteer')
 
-const rootUrl = "http://localhost:3000/";
+const rootUrl = "http://localhost:3001/";
 
 jest.setTimeout(500000);
 
 const server = new Promise( resolve => {
     let app = require( '../src/server' )({ directory: path.join( __dirname, '..' ) });
     let server;
-    server = app.listen( 3000, () => resolve(server) );
+    server = app.listen( 3001, () => resolve(server) );
 }).catch( e => console.log(e) );
 
 const browser = puppeteer.launch({ headless: false });

--- a/src/index.js
+++ b/src/index.js
@@ -540,8 +540,10 @@ const highlight = false;
 
                     uri.normalize();
 
-                    // use the normalized uri
-                    parentObject.update( uri.toString() );
+                    // use the normalized uri, unless it's empty (which happens when item == "#" and baseUrl is empty)
+                    if (uri.toString()) {
+                        parentObject.update( uri.toString() );
+                    }
 
                     debug(get_ref(uri));
                     get_ref( uri ).finally( () => {

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ const highlight = false;
                     try {
                         content = JSON.parse(content);
                     } catch(e) {
-                        console.error("Unable to parse "+segments[0], e);
+                        console.error("Unable to parse "+url, e, content);
                         content = {};
                     }
                 }

--- a/src/index.js
+++ b/src/index.js
@@ -572,6 +572,7 @@ const highlight = false;
                 return Promise.all(p).finally();
             };
             
+            schemaDocuments[baseUrl] = Promise.resolve(schema);
             resolveRefsReentrant(schema).finally( throttled_render ).then( resolve_d ).catch( e => console.log('oops', e )  );
         })
         return d.finally( throttled_render );


### PR DESCRIPTION
These commits fix several issues that became apparent in the revival of test.html, #81.

1. Fix a copy-paste error that causes missing output because an exception aborted rendering when a certain error occurs. This makes the test.html output identical again to what is currently at http://lbovet.github.io/docson/tests/test.html (which I am treating as the “known good baseline” for the purposes of this consideration, even though it has some problems itself).
2. Fix aforementioned error: The HTML page was mistakenly retrieved in an attempt to get the root schema, resulting in a JSON parsing error.
3. Fix a test that started failing due to behavior changed by 2., however I consider that behavior change an improvement and therefore changed the test. This changes the same lines as #79, which is why the commits are based on that, not on master.
4. Fix backreferences to the root (`{"$ref": "#"}`) not appearing in the output. This is an improvement over the “baseline” test.html output.
